### PR TITLE
Add demonstration of arduino/compile-sketches action

### DIFF
--- a/.github/workflows/compile-sketch.yml
+++ b/.github/workflows/compile-sketch.yml
@@ -1,0 +1,28 @@
+name: Compile Sketch
+
+# The workflow will run on every push and pull request to the repository
+on:
+  - push
+  - pull_request
+
+jobs:
+  compile-sketch:
+    runs-on: ubuntu-latest
+
+    steps:
+      # This step makes the contents of the repository available to the workflow
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      # For more information: https://github.com/arduino/compile-sketches#readme
+      - name: Compile sketch
+        uses: arduino/compile-sketches@v1
+        with:
+          # The default is to compile for the Arduino Uno board. If you want to compile for other boards, use the `fqbn` input.
+          sketch-paths: |
+            # Configure the action to search all folders under the root of the repository for sketches and compile them.
+            # This is formatted as a YAML list, which makes it possible to have multiple sketch paths if needed.
+            - ./
+          libraries: |
+            # The "blink" sketch being compiled in this demo doesn't use any libraries, so just use an empty list
+            -

--- a/README.md
+++ b/README.md
@@ -1,1 +1,10 @@
-# arduino-cli-example
+# `arduino/compile-sketches` action demo
+
+[![Compile Sketch status](https://github.com/arduino/arduino-cli-example/actions/workflows/compile-sketch.yml/badge.svg)](https://github.com/arduino/arduino-cli-example/actions/workflows/compile-sketch.yml)
+
+This repository is the companion of an article on Arduino's blog about tools for continuous integration testing of Arduino sketches with GitHub Actions.
+
+It only serves as a basic demonstration of the [`arduino/compile-sketches` GitHub Actions action](https://github.com/arduino/compile-sketches).
+
+- See the workflow [here](https://github.com/arduino/arduino-cli-example/blob/compile-sketches-demo/.github/workflows/compile-sketch.yml)
+- See the workflow runs [here](https://github.com/arduino/arduino-cli-example/actions/workflows/compile-sketch.yml)

--- a/blink/blink.ino
+++ b/blink/blink.ino
@@ -1,0 +1,10 @@
+void setup() {
+  pinMode(LED_BUILTIN, OUTPUT);
+}
+
+void loop() {
+  digitalWrite(LED_BUILTIN, HIGH);
+  delay(1000);
+  digitalWrite(LED_BUILTIN, LOW);
+  delay(1000);
+}


### PR DESCRIPTION
The GitHub Actions workflow provides a minimal demonstration of using [the `arduino/compile-sketches` action](https://github.com/arduino/compile-sketches) for a "smoke test" sketch compilation CI check.

Although it provides a higher level interface to the user, handling all the typical requirements for "smoke test" sketch compilation CI applications, the foundation of the `arduino/compile-sketches` action is still very much [Arduino CLI](https://github.com/arduino/arduino-cli).

This demonstration is stored in a dedicated `compile-sketches-demo` branch, so it has no impact on the demonstration of the more low level `arduino/setup-arduino-cli` action which is stored in the `master` branch.