### PR TITLE
Use major version refs of GitHub Actions actions

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -42,12 +42,12 @@ jobs:
     steps:
       # First of all, we clone the repo using the `checkout` action.
       - name: Checkout
-        uses: actions/checkout@master
+        uses: actions/checkout@v2
 
       # We use the `arduino/setup-arduino-cli` action to install and
       # configure the Arduino CLI on the system.
       - name: Setup Arduino CLI
-        uses: arduino/setup-arduino-cli@v1.0.0
+        uses: arduino/setup-arduino-cli@v1
 
       # We then install the platform, which one will be determined
       # dynamically by the build matrix.


### PR DESCRIPTION
Use of the major version ref will cause the workflow to benefit from ongoing development to the actions up until such
time as a new major release of an action is made, at which time we would need to evaluate whether any changes to the
workflow are required by the breaking change that triggered the major release before updating the major ref
(e.g., `uses: arduino/setup-arduino-cli@v2`).