### PR TITLE
[AE-45] Bump NodeJS version

### DIFF
--- a/.github/workflows/compile-sketch.yml
+++ b/.github/workflows/compile-sketch.yml
@@ -16,7 +16,7 @@ jobs:
 
       # For more information: https://github.com/arduino/compile-sketches#readme
       - name: Compile sketch
-        uses: arduino/compile-sketches@v1
+        uses: arduino/compile-sketches@v2
         with:
           # The default is to compile for the Arduino Uno board. If you want to compile for other boards, use the `fqbn` input.
           sketch-paths: |


### PR DESCRIPTION
actions/checkout@3 is already in use e.g. in the ArduinoBLE repo:

https://github.com/arduino-libraries/ArduinoBLE/blob/55e7bb6a625f8ef8fab2a72e21ab1185dfcd70c0/.github/workflows/compile-examples.yml#L20-L21

Updating the example to use v3, in line with Github's recommendation

![image](https://user-images.githubusercontent.com/75624145/234666103-aa08a054-a2bb-4156-82c7-0c9894a4f721.png)
