### PR TITLE
Merge compile-sketches-demo into main branch

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,24 @@
+This is free and unencumbered software released into the public domain.
+
+Anyone is free to copy, modify, publish, use, compile, sell, or
+distribute this software, either in source code form or as a compiled
+binary, for any purpose, commercial or non-commercial, and by any
+means.
+
+In jurisdictions that recognize copyright laws, the author or authors
+of this software dedicate any and all copyright interest in the
+software to the public domain. We make this dedication for the benefit
+of the public at large and to the detriment of our heirs and
+successors. We intend this dedication to be an overt act of
+relinquishment in perpetuity of all present and future rights to this
+software under copyright law.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+OTHER DEALINGS IN THE SOFTWARE.
+
+For more information, please refer to <http://unlicense.org>

--- a/README.md
+++ b/README.md
@@ -2,9 +2,10 @@
 
 [![Compile Sketch status](https://github.com/arduino/arduino-cli-example/actions/workflows/compile-sketch.yml/badge.svg)](https://github.com/arduino/arduino-cli-example/actions/workflows/compile-sketch.yml)
 
-This repository is the companion of an article on Arduino's blog about tools for continuous integration testing of Arduino sketches with GitHub Actions.
+This repository is the companion of [an article on Arduino's blog](https://blog.arduino.cc/2021/04/09/test-your-arduino-projects-with-github-actions/) about tools for continuous integration testing of Arduino sketches with GitHub Actions.
 
 It only serves as a basic demonstration of the [`arduino/compile-sketches` GitHub Actions action](https://github.com/arduino/compile-sketches).
 
+- See the blog post [here](https://blog.arduino.cc/2021/04/09/test-your-arduino-projects-with-github-actions/)
 - See the workflow [here](https://github.com/arduino/arduino-cli-example/blob/compile-sketches-demo/.github/workflows/compile-sketch.yml)
 - See the workflow runs [here](https://github.com/arduino/arduino-cli-example/actions/workflows/compile-sketch.yml)

--- a/README.md
+++ b/README.md
@@ -1,0 +1,1 @@
+# arduino-cli-example


### PR DESCRIPTION
The compile-sketches-demo branch includes a very informative, Hello World example of setting up the compile-sketches.yml action. This is mentioned on the [Arduino blog from 2021](https://blog.arduino.cc/2021/04/09/test-your-arduino-projects-with-github-actions/).

Could we merge this branch into the main/master branch for consistency? 