### PR TITLE
Configure Dependabot for action bumps in all production branches

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,3 +11,11 @@ updates:
       interval: daily
     labels:
       - "topic: infrastructure"
+
+  - package-ecosystem: github-actions
+    target-branch: dependabot-all-production-branches
+    directory: /
+    schedule:
+      interval: daily
+    labels:
+      - "topic: infrastructure"


### PR DESCRIPTION
This repository is used to host demonstrations related to using Arduino CLI with GitHub Actions. In addition to the demo of the "arduino/setup-arduino-cli" action hosted in the `master` branch, there is a demo of the "arduino/compile-sketches" action in the `dependabot-all-production-branches`. This branch is a permanent and maintained part of the repository rather than a temporary development or staging branch.

Dependabot is configured to periodically check the versions of all GitHub Actions actions used in the repository's workflows. If any are found to be outdated, it will automatically submit a pull request to update them. These updates are especially important in workflows that are used as a reference to the community for setting up continuous integration of their Arduino projects.

Previously, Dependabot was only configured to provide such updates for the workflows in the `master` branch, leaving maintenance (or lack thereof) of the workflow dependencies in the `dependabot-all-production-branches` branch to be handled entirely manually (e.g., https://github.com/arduino/arduino-cli-example/pull/16).

Dependabot is hereby configured to also provide update PRs for the workflow dependencies in the `dependabot-all-production-branches` branch.

---

Reference:

https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#target-branch

Note that, although not documented, Dependabot always uses the configuration file from the default branch of the repository, even for managing dependencies of another branch.

---

Example of the use of Dependabot to manage GitHub Actions action dependencies in multiple production branches:

https://github.com/arduino/library-registry/blob/main/.github/dependabot.yml