### PR TITLE
Correct target branch name in Dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,7 +13,7 @@ updates:
       - "topic: infrastructure"
 
   - package-ecosystem: github-actions
-    target-branch: dependabot-all-production-branches
+    target-branch: compile-sketches-demo
     directory: /
     schedule:
       interval: daily


### PR DESCRIPTION
This element of the configuration is intended to target the additional permanent production branch named `compile-sketches-demo`.

A copy/paste error resulted in the wrong branch name being specified in the configuration, which prevented the configuration from providing dependencies management of the intended target branch.